### PR TITLE
fix: issue #5

### DIFF
--- a/automation/server.js
+++ b/automation/server.js
@@ -279,6 +279,19 @@ async function commentGitHub(job, message) {
 // --- Code Review ---
 
 const MAX_DIFF_SIZE = 500 * 1024; // 500KB
+const IGNORED_REVIEW_EXTENSIONS = ['.md'];
+
+/** Divide o diff em blocos por arquivo e descarta os que terminam com extensão ignorada */
+function filterDiff(diff, ignoredExts) {
+  if (!diff) return diff;
+  const blocks = diff.split(/(?=^diff --git )/m);
+  return blocks.filter(block => {
+    const match = block.match(/^diff --git "?a\/(.+?)"? "?b\//m);
+    if (!match) return true;
+    const filePath = match[1];
+    return !ignoredExts.some(ext => filePath.endsWith(ext));
+  }).join('');
+}
 
 /** Clona o repo, faz checkout na branch do PR e retorna o diff contra a branch base */
 async function fetchPRDiff(job, worktreePath) {
@@ -290,6 +303,8 @@ async function fetchPRDiff(job, worktreePath) {
     `git diff origin/${job.targetBranch}...HEAD`,
     { cwd: worktreePath, encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
   );
+
+  diff = filterDiff(diff, IGNORED_REVIEW_EXTENSIONS);
 
   let truncated = false;
   if (Buffer.byteLength(diff, 'utf-8') > MAX_DIFF_SIZE) {
@@ -347,7 +362,7 @@ function fetchDiffFileList(job, worktreePath) {
   return execSync(
     `git diff --name-only origin/${job.targetBranch}...HEAD`,
     { cwd: worktreePath, encoding: 'utf-8' }
-  ).trim().split('\n').filter(Boolean);
+  ).trim().split('\n').filter(Boolean).filter(f => !IGNORED_REVIEW_EXTENSIONS.some(ext => f.endsWith(ext)));
 }
 
 // --- Pipeline SDD ---
@@ -848,6 +863,13 @@ async function executeReviewJob(job) {
     // Clonar e preparar repositório
     console.log(`[review] ${jobTag(job)} clonando repositório e preparando diff`);
     const { diff, truncated } = await fetchPRDiff(job, workDir);
+
+    if (!diff || diff.trim() === '') {
+      await commentOnPR(job, '📄 Este PR contém apenas arquivos de documentação (.md). Nenhum arquivo de código para revisar.');
+      job.status = 'done';
+      upsertJob(job);
+      return;
+    }
 
     if (truncated) {
       await commentOnPR(job, '⚠️ O diff deste PR é muito grande. O review será parcial (primeiros 500KB do diff).');

--- a/docs/specs/5-ignorar-arquivos-md-do-review/DESIGN.md
+++ b/docs/specs/5-ignorar-arquivos-md-do-review/DESIGN.md
@@ -1,0 +1,141 @@
+# Design Técnico — Issue #5: Ignorar arquivos MD do review
+
+## Contexto e Estado Atual
+
+O fluxo de code review é iniciado em `executeReviewJob` (`automation/server.js:835`) e segue estas etapas:
+
+1. `fetchPRDiff` (linha 284) — clona o repositório, faz checkout na branch fonte e retorna o diff bruto contra a branch base via `git diff origin/<target>...HEAD`.
+2. `fetchDiffFileList` (linha 346) — retorna a lista de arquivos modificados via `git diff --name-only`.
+3. O diff é passado a `buildCodeReviewPrompt`, que o envia ao Claude para análise.
+
+Atualmente, **nenhum filtro** é aplicado antes de enviar o diff ao Claude: arquivos `.md` são incluídos na análise, consumindo tokens e potencialmente gerando comentários irrelevantes sobre documentação.
+
+---
+
+## Abordagem Técnica
+
+### Estratégia escolhida: filtragem do diff em memória, pós-geração
+
+Após o `git diff` produzir o diff completo, aplicar uma função de filtragem que:
+1. Divide o diff em blocos por arquivo (cada bloco começa com `diff --git a/...`).
+2. Descarta blocos cujo caminho termine com extensão ignorada (ex.: `.md`).
+3. Retorna o diff filtrado para uso subsequente.
+
+A filtragem acontece dentro de `fetchPRDiff`, antes de qualquer truncamento por tamanho — garantindo que o limite de 500 KB se aplique somente a conteúdo relevante.
+
+A mesma lógica de extensões ignoradas é aplicada em `fetchDiffFileList` para manter consistência entre lista de arquivos e diff.
+
+**Por que não usar `git diff -- ':(exclude)*.md'`?**
+Seria possível usar um pathspec de exclusão diretamente no comando git. Porém, a filtragem em memória é preferível porque:
+- Centraliza a lógica de exclusão em um único lugar (JS), independente de flags de git.
+- Facilita adicionar extensões futuras sem alterar strings de shell.
+- Evita diferenças de comportamento entre versões do git.
+
+---
+
+## Componentes e Arquivos Modificados
+
+Apenas **`automation/server.js`** será modificado. Não serão criados novos arquivos.
+
+### 1. Constante `IGNORED_REVIEW_EXTENSIONS` (nova)
+
+```js
+const IGNORED_REVIEW_EXTENSIONS = ['.md'];
+```
+
+Localização: logo abaixo da constante `MAX_DIFF_SIZE` (linha 281), agrupando as constantes de review.
+
+Esta constante centraliza as extensões ignoradas, atendendo ao RNF-02 (manutenibilidade).
+
+### 2. Função auxiliar `filterDiff(diff, ignoredExts)` (nova)
+
+```js
+function filterDiff(diff, ignoredExts) { ... }
+```
+
+**Algoritmo:**
+- Divide o diff em blocos usando a expressão regular `/(?=^diff --git )/m` como separador.
+- Para cada bloco, extrai o caminho do arquivo da linha `diff --git a/<path> b/<path>`.
+- Descarta o bloco se o caminho terminar com uma das extensões em `ignoredExts`.
+- Concatena e retorna os blocos restantes.
+
+**Tratamento de edge cases:**
+- Diff vazio (`''`): retorna `''` sem processar.
+- Bloco sem caminho detectável: mantido (comportamento conservador).
+
+### 3. Modificação de `fetchPRDiff` (linha 284)
+
+Após obter o diff bruto do git e **antes** de aplicar o truncamento por `MAX_DIFF_SIZE`, aplicar:
+
+```js
+diff = filterDiff(diff, IGNORED_REVIEW_EXTENSIONS);
+```
+
+O truncamento permanece após a filtragem, pois o diff filtrado ainda pode ser grande para PRs com muitos arquivos de código.
+
+### 4. Modificação de `fetchDiffFileList` (linha 346)
+
+Após obter a lista via `git diff --name-only`, filtrar arquivos com extensão ignorada:
+
+```js
+.filter(f => !IGNORED_REVIEW_EXTENSIONS.some(ext => f.endsWith(ext)))
+```
+
+### 5. Tratamento de diff vazio em `executeReviewJob` (linha 835)
+
+Após chamar `fetchPRDiff`, verificar se o diff resultante está vazio:
+
+```js
+if (!diff || diff.trim() === '') {
+  await commentOnPR(job, '📄 Este PR contém apenas arquivos de documentação (.md). Nenhum arquivo de código para revisar.');
+  job.status = 'done';
+  upsertJob(job);
+  return;
+}
+```
+
+Este bloco é inserido antes da chamada a `fetchExistingComments` e `buildCodeReviewPrompt`, evitando invocação desnecessária do Claude.
+
+---
+
+## Modelos de Dados
+
+Sem alterações em estruturas de dados. Nenhum campo novo no objeto `job` é necessário.
+
+---
+
+## Decisões Técnicas
+
+| Decisão | Escolha | Alternativa considerada | Justificativa |
+|---|---|---|---|
+| Onde filtrar | Em memória, dentro de `fetchPRDiff` | Pathspec do git (`:(exclude)*.md`) | Centralização em JS; independente de versão do git |
+| Quando filtrar | Antes do truncamento por tamanho | Depois do truncamento | Garante que o limite de 500KB incide sobre conteúdo relevante |
+| Onde centralizar extensões | Constante `IGNORED_REVIEW_EXTENSIONS` | Constante inline / env var | Simples, sem over-engineering; env var fora do escopo |
+| Resposta para diff vazio | Comentar no PR e encerrar com `status: done` | Encerrar silenciosamente / status `skipped` | Comunicação transparente ao usuário; `done` é semanticamente correto (nenhuma ação necessária) |
+
+---
+
+## Riscos e Trade-offs
+
+### Risco 1 — Falso negativo no parsing do diff
+O algoritmo usa `diff --git a/<path>` para identificar o arquivo. Caminhos com espaços ou caracteres especiais são representados com aspas pelo git; a regex precisará cobrir ambos os formatos (`diff --git a/foo.md` e `diff --git "a/foo bar.md"`).
+
+**Mitigação:** Implementar extração de caminho que trate aspas e escape de caracteres conforme o formato padrão do git.
+
+### Risco 2 — Diff vazio em PRs apenas-MD
+Tratar como `done` e comentar no PR é a abordagem mais clara, mas o job não reaparecerá na fila para revisão posterior caso arquivos de código sejam adicionados ao PR depois. Entretanto, re-adicionar o label `ai-review` dispara um novo job, então o comportamento é aceitável.
+
+### Trade-off — Filtragem apenas de `.md`
+Arquivos `.mdx`, `.rst`, `.txt` não são filtrados (RF-04). A constante `IGNORED_REVIEW_EXTENSIONS` é facilmente extensível no futuro.
+
+---
+
+## Resumo das Alterações
+
+| Arquivo | Tipo | Descrição |
+|---|---|---|
+| `automation/server.js` | Modificação | Adicionar constante `IGNORED_REVIEW_EXTENSIONS` |
+| `automation/server.js` | Modificação | Adicionar função `filterDiff` |
+| `automation/server.js` | Modificação | Chamar `filterDiff` dentro de `fetchPRDiff` |
+| `automation/server.js` | Modificação | Filtrar extensões em `fetchDiffFileList` |
+| `automation/server.js` | Modificação | Tratar diff vazio em `executeReviewJob` |

--- a/docs/specs/5-ignorar-arquivos-md-do-review/REQUIREMENTS.md
+++ b/docs/specs/5-ignorar-arquivos-md-do-review/REQUIREMENTS.md
@@ -1,0 +1,66 @@
+# Requisitos — Issue #5: Ignorar arquivos MD do review
+
+## Resumo do Problema
+
+Durante o processo de code review automatizado, o agente analisa o diff completo de um PR, incluindo arquivos Markdown (`.md`). Arquivos de documentação raramente contêm bugs, vulnerabilidades de segurança ou problemas de performance — os focos principais do review automatizado. Incluí-los gera ruído desnecessário, consome tokens e tempo de processamento, e pode produzir comentários irrelevantes sobre conteúdo textual que não é código executável.
+
+## Requisitos Funcionais
+
+### RF-01 — Filtrar arquivos `.md` do diff de review
+O sistema deve excluir arquivos com extensão `.md` do diff enviado ao Claude para análise de code review.
+
+### RF-02 — Filtrar arquivos `.md` da lista de arquivos modificados
+A lista de arquivos retornada por `fetchDiffFileList` também deve excluir arquivos `.md`, pois essa lista pode ser usada para análise de impacto (busca de chamadores, etc.).
+
+### RF-03 — Manter comportamento quando nenhum arquivo não-MD é alterado
+Se um PR contiver apenas arquivos `.md`, o sistema deve lidar graciosamente com o diff vazio — seja ignorando o review ou postando uma mensagem adequada ao invés de invocar o Claude com diff vazio.
+
+### RF-04 — Não impactar outros tipos de arquivo
+Apenas arquivos `.md` devem ser filtrados. Arquivos `.mdx`, `.rst`, `.txt` e outros não devem ser afetados a menos que especificado futuramente.
+
+## Requisitos Não-Funcionais
+
+### RNF-01 — Performance
+A filtragem deve ser feita antes de passar o diff ao Claude, reduzindo o tamanho do payload processado e, consequentemente, o custo de tokens e tempo de resposta.
+
+### RNF-02 — Manutenibilidade
+A lista de extensões a ignorar deve estar centralizada em um único local no código (constante ou configuração), facilitando adições futuras.
+
+## Escopo
+
+### Incluído
+- Filtragem de arquivos `.md` no diff gerado por `fetchPRDiff` em `automation/server.js`
+- Filtragem de arquivos `.md` na lista retornada por `fetchDiffFileList` em `automation/server.js`
+- Tratamento do caso de diff vazio após filtragem (PR contendo apenas arquivos `.md`)
+
+### Excluído
+- Filtragem de outros tipos de arquivo de documentação (`.rst`, `.txt`, `.mdx`, etc.) — pode ser adicionado futuramente
+- Modificação do pipeline SDD (fases de requirements, design, tasks, implementation, finalize) — essas fases trabalham com código, não com diffs de PR
+- Configuração dinâmica via variável de ambiente ou arquivo de config (fora do escopo desta issue)
+
+## Critérios de Aceitação
+
+### CA-01
+**Dado** um PR que modifica arquivos `.md` e arquivos de código,
+**Quando** o review for executado,
+**Então** o diff enviado ao Claude não deve conter nenhuma entrada de arquivo `.md` (linhas `diff --git`, `--- a/`, `+++ b/` referentes a arquivos `.md`).
+
+### CA-02
+**Dado** um PR que modifica apenas arquivos `.md`,
+**Quando** o review for executado,
+**Então** o sistema não deve invocar o Claude com um diff vazio — deve postar uma mensagem informando que não há arquivos de código a revisar e encerrar o job com status `done`.
+
+### CA-03
+**Dado** um PR que não contém nenhum arquivo `.md`,
+**Quando** o review for executado,
+**Então** o comportamento deve ser idêntico ao atual (sem regressão).
+
+### CA-04
+**Dado** um PR que modifica arquivos `.mdx` ou outros formatos similares,
+**Quando** o review for executado,
+**Então** esses arquivos **não** devem ser filtrados (apenas `.md` é excluído).
+
+### CA-05
+**Dado** a lista de extensões ignoradas,
+**Quando** um desenvolvedor precisar adicionar novas extensões no futuro,
+**Então** deve existir uma única constante/variável no código onde essa adição pode ser feita.

--- a/docs/specs/5-ignorar-arquivos-md-do-review/TASKS.md
+++ b/docs/specs/5-ignorar-arquivos-md-do-review/TASKS.md
@@ -2,21 +2,21 @@
 
 ## 1. Constante de Configuração
 
-- [ ] 1.1 Adicionar constante `IGNORED_REVIEW_EXTENSIONS` em `automation/server.js` logo abaixo da constante `MAX_DIFF_SIZE` (linha ~281), com valor `['.md']`
+- [x] 1.1 Adicionar constante `IGNORED_REVIEW_EXTENSIONS` em `automation/server.js` logo abaixo da constante `MAX_DIFF_SIZE` (linha ~281), com valor `['.md']`
 
 ## 2. Função de Filtragem
 
-- [ ] 2.1 Implementar função auxiliar `filterDiff(diff, ignoredExts)` em `automation/server.js`, que divide o diff em blocos por arquivo (`diff --git`), descarta blocos cujo caminho termine com extensão ignorada e retorna o diff filtrado
-- [ ] 2.2 Garantir que `filterDiff` trata corretamente edge cases: diff vazio (`''`), blocos sem caminho detectável (mantidos), e caminhos com aspas/caracteres especiais no formato git
+- [x] 2.1 Implementar função auxiliar `filterDiff(diff, ignoredExts)` em `automation/server.js`, que divide o diff em blocos por arquivo (`diff --git`), descarta blocos cujo caminho termine com extensão ignorada e retorna o diff filtrado
+- [x] 2.2 Garantir que `filterDiff` trata corretamente edge cases: diff vazio (`''`), blocos sem caminho detectável (mantidos), e caminhos com aspas/caracteres especiais no formato git
 
 ## 3. Filtragem em `fetchPRDiff`
 
-- [ ] 3.1 Chamar `filterDiff(diff, IGNORED_REVIEW_EXTENSIONS)` dentro de `fetchPRDiff` (`automation/server.js` linha ~284), após obter o diff bruto do git e **antes** de aplicar o truncamento por `MAX_DIFF_SIZE`
+- [x] 3.1 Chamar `filterDiff(diff, IGNORED_REVIEW_EXTENSIONS)` dentro de `fetchPRDiff` (`automation/server.js` linha ~284), após obter o diff bruto do git e **antes** de aplicar o truncamento por `MAX_DIFF_SIZE`
 
 ## 4. Filtragem em `fetchDiffFileList`
 
-- [ ] 4.1 Aplicar filtro na lista retornada por `fetchDiffFileList` (`automation/server.js` linha ~346) para excluir arquivos cuja extensão esteja em `IGNORED_REVIEW_EXTENSIONS`, usando `.filter(f => !IGNORED_REVIEW_EXTENSIONS.some(ext => f.endsWith(ext)))`
+- [x] 4.1 Aplicar filtro na lista retornada por `fetchDiffFileList` (`automation/server.js` linha ~346) para excluir arquivos cuja extensão esteja em `IGNORED_REVIEW_EXTENSIONS`, usando `.filter(f => !IGNORED_REVIEW_EXTENSIONS.some(ext => f.endsWith(ext)))`
 
 ## 5. Tratamento de Diff Vazio
 
-- [ ] 5.1 Adicionar verificação em `executeReviewJob` (`automation/server.js` linha ~835), logo após a chamada a `fetchPRDiff`, que detecta diff vazio ou só-espaços, posta comentário no PR informando que apenas arquivos de documentação foram alterados, define `job.status = 'done'`, persiste o job e encerra a função sem invocar o Claude
+- [x] 5.1 Adicionar verificação em `executeReviewJob` (`automation/server.js` linha ~835), logo após a chamada a `fetchPRDiff`, que detecta diff vazio ou só-espaços, posta comentário no PR informando que apenas arquivos de documentação foram alterados, define `job.status = 'done'`, persiste o job e encerra a função sem invocar o Claude

--- a/docs/specs/5-ignorar-arquivos-md-do-review/TASKS.md
+++ b/docs/specs/5-ignorar-arquivos-md-do-review/TASKS.md
@@ -1,0 +1,22 @@
+# Tarefas — Issue #5: Ignorar arquivos MD do review
+
+## 1. Constante de Configuração
+
+- [ ] 1.1 Adicionar constante `IGNORED_REVIEW_EXTENSIONS` em `automation/server.js` logo abaixo da constante `MAX_DIFF_SIZE` (linha ~281), com valor `['.md']`
+
+## 2. Função de Filtragem
+
+- [ ] 2.1 Implementar função auxiliar `filterDiff(diff, ignoredExts)` em `automation/server.js`, que divide o diff em blocos por arquivo (`diff --git`), descarta blocos cujo caminho termine com extensão ignorada e retorna o diff filtrado
+- [ ] 2.2 Garantir que `filterDiff` trata corretamente edge cases: diff vazio (`''`), blocos sem caminho detectável (mantidos), e caminhos com aspas/caracteres especiais no formato git
+
+## 3. Filtragem em `fetchPRDiff`
+
+- [ ] 3.1 Chamar `filterDiff(diff, IGNORED_REVIEW_EXTENSIONS)` dentro de `fetchPRDiff` (`automation/server.js` linha ~284), após obter o diff bruto do git e **antes** de aplicar o truncamento por `MAX_DIFF_SIZE`
+
+## 4. Filtragem em `fetchDiffFileList`
+
+- [ ] 4.1 Aplicar filtro na lista retornada por `fetchDiffFileList` (`automation/server.js` linha ~346) para excluir arquivos cuja extensão esteja em `IGNORED_REVIEW_EXTENSIONS`, usando `.filter(f => !IGNORED_REVIEW_EXTENSIONS.some(ext => f.endsWith(ext)))`
+
+## 5. Tratamento de Diff Vazio
+
+- [ ] 5.1 Adicionar verificação em `executeReviewJob` (`automation/server.js` linha ~835), logo após a chamada a `fetchPRDiff`, que detecta diff vazio ou só-espaços, posta comentário no PR informando que apenas arquivos de documentação foram alterados, define `job.status = 'done'`, persiste o job e encerra a função sem invocar o Claude


### PR DESCRIPTION
## Resumo

Corrige o comportamento do agente de review para ignorar arquivos `.md` durante a análise de código.

Antes desta correção, arquivos Markdown (como README, documentação, changelogs, etc.) eram incluídos no processo de review, gerando ruído desnecessário e análises irrelevantes.

## Mudanças

- Adicionada lógica para filtrar/ignorar arquivos com extensão `.md` no processo de review
- Apenas arquivos de código são enviados para análise

## Issue relacionada

Fecha #5
