### PR TITLE
fix: issue #6 - handleWebhook deve ser declarada como async

### DIFF
--- a/docs/specs/6-severidade-critical-bug/DESIGN.md
+++ b/docs/specs/6-severidade-critical-bug/DESIGN.md
@@ -1,0 +1,197 @@
+# Design Técnico — Issue #6: handleWebhook deve ser declarada como async
+
+## 1. Contexto e Estado Atual
+
+### Estado antes do fix (pré-commit `aa5724b`)
+
+A função `handleWebhook` em `automation/server.js` era declarada como síncrona:
+
+```js
+function handleWebhook(headers, body, res) { ... }
+```
+
+Internamente, porém, ela continha dois usos de `await`:
+
+- **Linha ~1089** (PR/review job): `await blockJob(job, 'title', titleCheckReview, commentOnPR)`
+- **Linha ~1136** (issue job): `await blockJob(job, field, result, commentOnIssue)`
+
+O chamador no handler HTTP também não tratava nenhuma Promise:
+
+```js
+req.on('end', () => {
+  handleWebhook(req.headers, body, res);  // Promise ignorada
+});
+```
+
+### Estado após o fix (commit `aa5724b` — estado atual no código)
+
+`handleWebhook` é declarada como `async` (linha 1047):
+
+```js
+async function handleWebhook(headers, body, res) { ... }
+```
+
+O chamador trata a Promise com `.catch()` (linha 1037):
+
+```js
+handleWebhook(req.headers, body, res).catch((err) => {
+  console.error('[erro] Falha ao processar webhook:', err.message);
+  if (!res.headersSent) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Internal error' }));
+  }
+});
+```
+
+---
+
+## 2. Análise do Bug
+
+### Cenário 1 — Node.js v16+
+
+`await` fora de uma função `async` (exceto em ES Modules top-level) é um `SyntaxError` em tempo de parse. O processo Node.js lança o erro ao carregar o arquivo e **nunca inicializa**. O servidor simplesmente não sobe.
+
+### Cenário 2 — Node.js < v16
+
+`await` como identificador common (não-reservado em contexto síncrono antigo) faz com que `await blockJob(...)` seja avaliado como expressão que ignora a Promise retornada. O job seria enfileirado normalmente mesmo quando prompt injection for detectado — a feature de segurança introduzida na issue #3 seria completamente ineficaz.
+
+---
+
+## 3. Abordagem Técnica
+
+### Decisão: Mínima e cirúrgica
+
+A correção exige exatamente **duas mudanças** no arquivo `automation/server.js`:
+
+| # | Local | Mudança |
+|---|-------|---------|
+| 1 | Declaração de `handleWebhook` | Adicionar `async` à declaração da função |
+| 2 | Chamada de `handleWebhook` no handler `req.on('end', ...)` | Encadear `.catch()` na chamada para capturar rejeições da Promise |
+
+Nenhuma outra alteração é necessária: a lógica interna, o fluxo de roteamento, os formatos de resposta HTTP e as funções auxiliares (`blockJob`, `detectPromptInjection`, `commentOnIssue`, `commentOnPR`) permanecem inalterados.
+
+### Por que `.catch()` e não `await` no chamador?
+
+O handler `req.on('end', callback)` é uma callback síncrona do Node.js — não pode ser declarada `async` sem risco de silenciar erros (uma `async` callback passada para `req.on` torna a Promise resultado invisível para o emissor de eventos). O padrão correto é encadear `.catch()` para garantir que rejeições sejam capturadas e tratadas, retornando HTTP 500 com body `{ error: 'Internal error' }`.
+
+Alternativa descartada: tornar a callback `async`:
+```js
+req.on('end', async () => { await handleWebhook(...); });
+```
+Embora funcione na prática para este caso, não é idiomático — erros não capturados dentro de uma `async` callback de EventEmitter podem produzir `UnhandledPromiseRejection` dependendo da versão do Node.js e da configuração. O `.catch()` explícito é mais robusto e legível.
+
+---
+
+## 4. Componentes Modificados
+
+### `automation/server.js`
+
+Único arquivo alterado. Duas linhas modificadas:
+
+**Mudança 1 — Declaração da função (linha 1047 no estado atual):**
+```js
+// Antes:
+function handleWebhook(headers, body, res) {
+
+// Depois:
+async function handleWebhook(headers, body, res) {
+```
+
+**Mudança 2 — Chamador (dentro do handler `req.on('end', ...)`):**
+```js
+// Antes:
+req.on('end', () => {
+  handleWebhook(req.headers, body, res);
+});
+
+// Depois:
+req.on('end', () => {
+  handleWebhook(req.headers, body, res).catch((err) => {
+    console.error('[erro] Falha ao processar webhook:', err.message);
+    if (!res.headersSent) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: 'Internal error' }));
+    }
+  });
+});
+```
+
+### Arquivos não modificados
+
+- `automation/promptInjectionDetector.js` — lógica de detecção inalterada
+- `automation/jobStore.js` — persistência inalterada
+- `automation/prompts.js` — builders de prompt inalterados
+- Qualquer arquivo de teste existente (sem modificação de comportamento)
+
+---
+
+## 5. Modelos de Dados
+
+Nenhuma mudança em modelos de dados. O shape do `job` object, o formato do `jobStore`, e os payloads de resposta HTTP permanecem idênticos.
+
+---
+
+## 6. Fluxo de Execução (pós-fix)
+
+```
+POST /webhook
+  └─► req.on('end', () => {
+        handleWebhook(...).catch(errorHandler)   ← Promise retornada e capturada
+          │
+          ├─► [PR event + ai-review label]
+          │     └─► detectPromptInjection(title)
+          │           ├─ detected → await blockJob(...)  ← agora corretamente aguardado
+          │           │             res.end({ status: 'blocked' })
+          │           └─ clean   → enqueue(job)
+          │                        res.end({ status: 'queued' })
+          │
+          └─► [Issue event + ai-fix label]
+                └─► detectPromptInjection(title) + detectPromptInjection(description)
+                      ├─ detected → await blockJob(...)  ← agora corretamente aguardado
+                      │             res.end({ status: 'blocked' })
+                      └─ clean   → enqueue(job)
+                                   res.end({ status: 'queued' })
+      })
+```
+
+---
+
+## 7. Decisões Técnicas
+
+| Decisão | Escolha | Alternativa Descartada | Justificativa |
+|---------|---------|------------------------|---------------|
+| Escopo da correção | Apenas `handleWebhook` + chamador | Refatorar toda a função | Minimiza risco de regressão; o bug é pontual |
+| Tratamento de erros no chamador | `.catch()` explícito | `async` callback no `req.on` | Mais idiomático; evita `UnhandledPromiseRejection` silenciosos |
+| Resposta HTTP em erro interno | `500 { error: 'Internal error' }` | Re-throw / sem resposta | Garante que o cliente receba uma resposta mesmo em caso de falha |
+| Guard `res.headersSent` | Verificar antes de escrever | Sempre escrever | Previne erro `Cannot set headers after they are sent` |
+
+---
+
+## 8. Riscos e Trade-offs
+
+### Riscos
+
+| Risco | Probabilidade | Mitigação |
+|-------|--------------|-----------|
+| Regressão em fluxos síncronos de `handleWebhook` | Baixa | `async` em função sem `await` é transparente — comportamento idêntico |
+| `.catch()` mascarar erros legítimos | Baixa | O `.catch()` loga o erro via `console.error` antes de responder com 500 |
+| Dupla resposta HTTP (`res.end` + `.catch` tentando escrever) | Baixa | Guard `res.headersSent` previne a condição |
+
+### Trade-offs aceitos
+
+- A função `handleWebhook` passa a retornar uma `Promise`, mas como o chamador trata corretamente com `.catch()`, não há efeito observável para os clientes do webhook.
+- Nenhum teste novo é criado nesta fase de Design; a validação é delegada à suite existente (critério CA-07) e aos critérios de aceitação funcionais (CA-01 a CA-06).
+
+---
+
+## 9. Compatibilidade
+
+- `async/await` é suportado desde **Node.js v7.6** (janeiro 2017).
+- O projeto utiliza constructs `async/await` em diversas outras funções do mesmo arquivo (`processNext`, `executeJob`, `commentOnIssue`, etc.), confirmando que o ambiente suporta a feature.
+- Nenhuma dependência nova é introduzida.
+
+---
+
+## 10. Status de Implementação
+
+O fix foi aplicado no commit `aa5724b` na branch `fix/issue-6`. Este documento registra o design para fins de rastreabilidade e validação no pipeline SDD.

--- a/docs/specs/6-severidade-critical-bug/REQUIREMENTS.md
+++ b/docs/specs/6-severidade-critical-bug/REQUIREMENTS.md
@@ -1,0 +1,123 @@
+# Requisitos — Issue #6: handleWebhook deve ser declarada como async
+
+## Resumo do Problema
+
+A função `handleWebhook` em `automation/server.js` foi originalmente declarada como função síncrona (`function handleWebhook(...)`), mas o código interno utiliza `await blockJob(...)` em dois pontos distintos (detecção de prompt injection em review jobs e em issue jobs).
+
+Este é um bug crítico com dois cenários de falha dependendo da versão do Node.js:
+
+- **Node.js v16+**: `await` fora de uma função `async` é um `SyntaxError` que impede o processo de iniciar completamente — o servidor não sobe.
+- **Node.js < v16**: `await` seria tratado como identificador, a Promise retornada por `blockJob` nunca seria aguardada, e jobs com prompt injection detectado seriam enfileirados normalmente — a feature de segurança se tornaria completamente ineficaz.
+
+### Contexto Adicional
+
+O bug foi introduzido pelo fix da issue #3 (proteção contra prompt injection), que adicionou chamadas `await blockJob(...)` dentro de `handleWebhook` sem converter a função para `async`. O caller do webhook também precisava ser ajustado para tratar a Promise retornada.
+
+**Status atual**: O commit `aa5724b` já aplicou o fix na branch `main`. Esta fase de Requirements documenta os requisitos para validação e rastreabilidade do pipeline SDD.
+
+---
+
+## Requisitos Funcionais
+
+### RF-01: Declaração assíncrona de handleWebhook
+A função `handleWebhook` em `automation/server.js` deve ser declarada como `async`:
+```js
+async function handleWebhook(headers, body, res) { ... }
+```
+
+### RF-02: Chamador deve tratar a Promise retornada
+O código que invoca `handleWebhook` (dentro do handler HTTP em `req.on('end', ...)`) deve tratar a Promise retornada. A abordagem correta é usar `.catch()` para capturar erros não tratados:
+```js
+handleWebhook(req.headers, body, res).catch((err) => {
+  console.error('[erro] Falha ao processar webhook:', err.message);
+  if (!res.headersSent) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: 'Internal error' }));
+  }
+});
+```
+
+### RF-03: Comportamento correto do await blockJob
+Todas as chamadas `await blockJob(...)` dentro de `handleWebhook` devem ser corretamente aguardadas, garantindo que:
+- O job seja marcado como `blocked` no jobStore antes de responder ao webhook
+- O comentário de notificação seja postado na issue/PR antes de responder
+- A resposta HTTP retorne `{ status: 'blocked', reason: 'prompt_injection' }` somente após a conclusão do bloqueio
+
+### RF-04: Pontos de verificação de prompt injection ativos
+Os dois pontos de verificação devem funcionar corretamente:
+1. **Review job (PR)**: verificação do campo `title` antes de enfileirar um job de review
+2. **Issue job**: verificação dos campos `title` e `description` antes de enfileirar um job de fix
+
+---
+
+## Requisitos Não-Funcionais
+
+### RNF-01: Sem regressão de comportamento
+A mudança de síncrona para assíncrona não deve alterar nenhum comportamento observável além de corrigir o bug — tempo de resposta, formato de resposta HTTP e lógica de roteamento devem permanecer iguais.
+
+### RNF-02: Compatibilidade com Node.js
+A correção deve funcionar nas versões de Node.js suportadas pelo projeto (atualmente indicadas no ambiente de execução). A declaração `async/await` é suportada desde Node.js v7.6.
+
+### RNF-03: Segurança — proteção contra prompt injection efetiva
+Após a correção, a feature de bloqueio de prompt injection (introduzida na issue #3) deve ser efetiva: jobs com conteúdo malicioso detectado NÃO devem ser enfileirados.
+
+---
+
+## Escopo
+
+### Incluído
+- Alteração da declaração de `handleWebhook` para `async`
+- Ajuste do chamador para tratar a Promise (`.catch()`)
+- Verificação de que todas as chamadas `await blockJob(...)` dentro de `handleWebhook` funcionam corretamente
+
+### Excluído
+- Refatoração de outras funções no servidor
+- Alterações na lógica de detecção de prompt injection (`detectPromptInjection`, `blockJob`)
+- Mudanças nos testes existentes além do necessário para refletir o comportamento corrigido
+- Adição de novos pontos de verificação de prompt injection além dos já existentes
+
+---
+
+## Critérios de Aceitação
+
+### CA-01: Servidor inicializa sem erros
+Dado que o servidor é iniciado com `node server.js`,
+Quando o processo é inicializado,
+Então não deve haver `SyntaxError` relacionado a `await` fora de função `async`.
+
+### CA-02: Webhook com prompt injection em título de issue é bloqueado
+Dado um webhook de issue com label `ai-fix` onde o título contém padrão de prompt injection,
+Quando o webhook é recebido,
+Então a resposta deve ser `{ status: 'blocked', reason: 'prompt_injection' }` (HTTP 200),
+E o job NÃO deve ser enfileirado,
+E o jobStore deve registrar o job com `status: 'blocked'`,
+E um comentário de notificação deve ser postado na issue.
+
+### CA-03: Webhook com prompt injection em descrição de issue é bloqueado
+Dado um webhook de issue com label `ai-fix` onde a descrição contém padrão de prompt injection,
+Quando o webhook é recebido,
+Então a resposta deve ser `{ status: 'blocked', reason: 'prompt_injection' }` (HTTP 200),
+E o job NÃO deve ser enfileirado.
+
+### CA-04: Webhook com prompt injection em título de PR é bloqueado
+Dado um webhook de PR com label `ai-review` onde o título contém padrão de prompt injection,
+Quando o webhook é recebido,
+Então a resposta deve ser `{ status: 'blocked', reason: 'prompt_injection' }` (HTTP 200),
+E o job NÃO deve ser enfileirado.
+
+### CA-05: Webhook legítimo continua sendo enfileirado
+Dado um webhook de issue com label `ai-fix` sem conteúdo de prompt injection,
+Quando o webhook é recebido,
+Então a resposta deve ser `{ status: 'queued' }` (HTTP 200),
+E o job deve ser enfileirado normalmente.
+
+### CA-06: Erros internos retornam HTTP 500
+Dado que ocorra uma exceção dentro de `handleWebhook`,
+Quando o webhook é processado,
+Então a resposta deve ser HTTP 500 com `{ error: 'Internal error' }`,
+E o erro deve ser logado no console.
+
+### CA-07: Testes existentes passam sem modificação de comportamento
+Dado que os testes em `automation/` sejam executados com `npm test`,
+Quando a suite é rodada após a correção,
+Então todos os testes devem passar.

--- a/docs/specs/6-severidade-critical-bug/TASKS.md
+++ b/docs/specs/6-severidade-critical-bug/TASKS.md
@@ -1,0 +1,28 @@
+# Tarefas — Issue #6: handleWebhook deve ser declarada como async
+
+## 1. Verificação do Estado Atual
+
+- [ ] 1.1 Verificar que `handleWebhook` em `automation/server.js` está declarada como `async function handleWebhook(headers, body, res)`
+- [ ] 1.2 Verificar que o chamador em `req.on('end', ...)` encadeia `.catch()` na chamada de `handleWebhook`
+- [ ] 1.3 Confirmar que os dois pontos com `await blockJob(...)` estão dentro de uma função `async` válida
+
+## 2. Implementação do Fix (automation/server.js)
+
+- [ ] 2.1 Alterar declaração de `handleWebhook` de síncrona para `async` (linha ~1047 em `automation/server.js`)
+- [ ] 2.2 Encadear `.catch((err) => { ... })` na chamada `handleWebhook(req.headers, body, res)` dentro do handler `req.on('end', ...)` (linha ~1037 em `automation/server.js`)
+- [ ] 2.3 Garantir que o `.catch()` loga o erro via `console.error` e responde com HTTP 500 e `{ error: 'Internal error' }` quando `!res.headersSent`
+
+## 3. Validação dos Pontos de await
+
+- [ ] 3.1 Confirmar que `await blockJob(...)` no fluxo de PR/review job (detecção em `title`) está corretamente aguardado após o fix
+- [ ] 3.2 Confirmar que `await blockJob(...)` no fluxo de issue job (detecção em `title` e `description`) está corretamente aguardado após o fix
+
+## 4. Testes e Critérios de Aceitação
+
+- [ ] 4.1 Executar `npm test` em `automation/` e confirmar que todos os testes existentes passam (CA-07)
+- [ ] 4.2 Verificar manualmente (ou via teste) que servidor inicia sem `SyntaxError` (CA-01)
+- [ ] 4.3 Verificar que webhook com prompt injection em título de PR retorna `{ status: 'blocked', reason: 'prompt_injection' }` e não enfileira o job (CA-04)
+- [ ] 4.4 Verificar que webhook com prompt injection em título de issue retorna `{ status: 'blocked', reason: 'prompt_injection' }` e não enfileira o job (CA-02)
+- [ ] 4.5 Verificar que webhook com prompt injection em descrição de issue retorna `{ status: 'blocked', reason: 'prompt_injection' }` e não enfileira o job (CA-03)
+- [ ] 4.6 Verificar que webhook legítimo (sem prompt injection) continua sendo enfileirado normalmente com `{ status: 'queued' }` (CA-05)
+- [ ] 4.7 Verificar que erros internos retornam HTTP 500 com `{ error: 'Internal error' }` (CA-06)

--- a/docs/specs/6-severidade-critical-bug/TASKS.md
+++ b/docs/specs/6-severidade-critical-bug/TASKS.md
@@ -2,27 +2,27 @@
 
 ## 1. Verificação do Estado Atual
 
-- [ ] 1.1 Verificar que `handleWebhook` em `automation/server.js` está declarada como `async function handleWebhook(headers, body, res)`
-- [ ] 1.2 Verificar que o chamador em `req.on('end', ...)` encadeia `.catch()` na chamada de `handleWebhook`
-- [ ] 1.3 Confirmar que os dois pontos com `await blockJob(...)` estão dentro de uma função `async` válida
+- [x] 1.1 Verificar que `handleWebhook` em `automation/server.js` está declarada como `async function handleWebhook(headers, body, res)`
+- [x] 1.2 Verificar que o chamador em `req.on('end', ...)` encadeia `.catch()` na chamada de `handleWebhook`
+- [x] 1.3 Confirmar que os dois pontos com `await blockJob(...)` estão dentro de uma função `async` válida
 
 ## 2. Implementação do Fix (automation/server.js)
 
-- [ ] 2.1 Alterar declaração de `handleWebhook` de síncrona para `async` (linha ~1047 em `automation/server.js`)
-- [ ] 2.2 Encadear `.catch((err) => { ... })` na chamada `handleWebhook(req.headers, body, res)` dentro do handler `req.on('end', ...)` (linha ~1037 em `automation/server.js`)
-- [ ] 2.3 Garantir que o `.catch()` loga o erro via `console.error` e responde com HTTP 500 e `{ error: 'Internal error' }` quando `!res.headersSent`
+- [x] 2.1 Alterar declaração de `handleWebhook` de síncrona para `async` (linha ~1047 em `automation/server.js`)
+- [x] 2.2 Encadear `.catch((err) => { ... })` na chamada `handleWebhook(req.headers, body, res)` dentro do handler `req.on('end', ...)` (linha ~1037 em `automation/server.js`)
+- [x] 2.3 Garantir que o `.catch()` loga o erro via `console.error` e responde com HTTP 500 e `{ error: 'Internal error' }` quando `!res.headersSent`
 
 ## 3. Validação dos Pontos de await
 
-- [ ] 3.1 Confirmar que `await blockJob(...)` no fluxo de PR/review job (detecção em `title`) está corretamente aguardado após o fix
-- [ ] 3.2 Confirmar que `await blockJob(...)` no fluxo de issue job (detecção em `title` e `description`) está corretamente aguardado após o fix
+- [x] 3.1 Confirmar que `await blockJob(...)` no fluxo de PR/review job (detecção em `title`) está corretamente aguardado após o fix
+- [x] 3.2 Confirmar que `await blockJob(...)` no fluxo de issue job (detecção em `title` e `description`) está corretamente aguardado após o fix
 
 ## 4. Testes e Critérios de Aceitação
 
-- [ ] 4.1 Executar `npm test` em `automation/` e confirmar que todos os testes existentes passam (CA-07)
-- [ ] 4.2 Verificar manualmente (ou via teste) que servidor inicia sem `SyntaxError` (CA-01)
-- [ ] 4.3 Verificar que webhook com prompt injection em título de PR retorna `{ status: 'blocked', reason: 'prompt_injection' }` e não enfileira o job (CA-04)
-- [ ] 4.4 Verificar que webhook com prompt injection em título de issue retorna `{ status: 'blocked', reason: 'prompt_injection' }` e não enfileira o job (CA-02)
-- [ ] 4.5 Verificar que webhook com prompt injection em descrição de issue retorna `{ status: 'blocked', reason: 'prompt_injection' }` e não enfileira o job (CA-03)
-- [ ] 4.6 Verificar que webhook legítimo (sem prompt injection) continua sendo enfileirado normalmente com `{ status: 'queued' }` (CA-05)
-- [ ] 4.7 Verificar que erros internos retornam HTTP 500 com `{ error: 'Internal error' }` (CA-06)
+- [x] 4.1 Executar `npm test` em `automation/` e confirmar que todos os testes existentes passam (CA-07)
+- [x] 4.2 Verificar manualmente (ou via teste) que servidor inicia sem `SyntaxError` (CA-01)
+- [x] 4.3 Verificar que webhook com prompt injection em título de PR retorna `{ status: 'blocked', reason: 'prompt_injection' }` e não enfileira o job (CA-04)
+- [x] 4.4 Verificar que webhook com prompt injection em título de issue retorna `{ status: 'blocked', reason: 'prompt_injection' }` e não enfileira o job (CA-02)
+- [x] 4.5 Verificar que webhook com prompt injection em descrição de issue retorna `{ status: 'blocked', reason: 'prompt_injection' }` e não enfileira o job (CA-03)
+- [x] 4.6 Verificar que webhook legítimo (sem prompt injection) continua sendo enfileirado normalmente com `{ status: 'queued' }` (CA-05)
+- [x] 4.7 Verificar que erros internos retornam HTTP 500 com `{ error: 'Internal error' }` (CA-06)


### PR DESCRIPTION
## Resumo

Corrige bug crítico onde a função `handleWebhook` em `automation/server.js` era declarada como síncrona, mas utilizava `await blockJob(...)` internamente.

**Cenários de falha antes do fix:**
- Node.js v16+: `SyntaxError` impedia o servidor de iniciar
- Node.js < v16: Promises não aguardadas tornavam a proteção contra prompt injection ineficaz

## Mudanças

- Convertida `handleWebhook` de `function` para `async function`
- Adicionado `.catch()` no chamador para tratar erros não capturados com HTTP 500

## Referências

Fix para issue #6

Contexto: bug introduzido pelo fix da issue #3 (proteção contra prompt injection) que adicionou `await blockJob(...)` sem converter a função para `async`.