### PR TITLE
fix: issue #12

### DIFF
--- a/automation/server.js
+++ b/automation/server.js
@@ -924,7 +924,7 @@ async function executeReviewJob(job) {
     const existingComments = await fetchExistingComments(job);
     console.log(`[review] ${jobTag(job)} comentários existentes: ${existingComments ? 'sim' : 'nenhum'}`);
 
-    // Ponto de verificação 2 — verificar existingComments antes de passar ao Claude
+    // Ponto de verificação 3 — verificar existingComments antes de passar ao Claude
     if (existingComments) {
       const commentsCheck = detectPromptInjection(existingComments);
       if (commentsCheck.detected) {

--- a/docs/specs/12-severidade-low-quality/DESIGN.md
+++ b/docs/specs/12-severidade-low-quality/DESIGN.md
@@ -1,0 +1,66 @@
+# Design Técnico — Issue #12: Comentário duplicado em `executeReviewJob`
+
+## Contexto e Estado Atual
+
+No arquivo `automation/server.js`, a função `executeReviewJob` contém dois pontos de verificação de injeção de prompt (prompt injection) com identificadores idênticos:
+
+- **Linha 916:** `// Ponto de verificação 2 — verificar diff antes de passar ao Claude`
+- **Linha 927:** `// Ponto de verificação 2 — verificar existingComments antes de passar ao Claude`
+
+Ambos têm o mesmo número de sequência (`2`), o que prejudica legibilidade e rastreabilidade. O padrão existente no arquivo usa numeração sequencial com sufixo descritivo, conforme evidenciado por:
+
+- Linha 1086: `// Ponto de verificação 1 — review job: verificar title`
+- Linha 1128: `// Ponto de verificação 1 — issue job: verificar title e description`
+
+## Abordagem Técnica
+
+Alterar **apenas o texto** do comentário na linha 927, renumerando de `2` para `3` para manter sequencialidade dentro de `executeReviewJob`:
+
+**Antes:**
+```js
+// Ponto de verificação 2 — verificar existingComments antes de passar ao Claude
+```
+
+**Depois:**
+```js
+// Ponto de verificação 3 — verificar existingComments antes de passar ao Claude
+```
+
+O comentário da linha 916 permanece inalterado — já está correto como `// Ponto de verificação 2`.
+
+### Justificativa
+
+- Segue o padrão já estabelecido no arquivo (numeração sequencial + sufixo descritivo).
+- Alteração mínima: apenas o número `2` → `3` no segundo comentário.
+- Zero impacto em runtime — comentários não afetam execução.
+
+## Componentes / Arquivos Modificados
+
+| Arquivo | Linha | Tipo de Alteração |
+|---|---|---|
+| `automation/server.js` | 927 | Texto de comentário (`2` → `3`) |
+
+Nenhum outro arquivo será criado ou modificado.
+
+## Modelos de Dados
+
+Não aplicável — alteração puramente cosmética em comentário.
+
+## Decisões Técnicas
+
+### Alternativa A (escolhida): renumerar o segundo comentário para `3`
+- Mantém consistência com o padrão sequencial do arquivo.
+- Mínima alteração (1 caractere).
+
+### Alternativa B: usar nomes descritivos sem numeração
+- Ex: `// Verificação de injeção no diff` e `// Verificação de injeção nos comentários existentes`
+- Descartada: foge do padrão `// Ponto de verificação N — ...` já consolidado no arquivo.
+
+### Alternativa C: alterar ambos os comentários
+- Desnecessário; o primeiro já está correto e legível.
+- Descartada para manter o escopo mínimo.
+
+## Riscos e Trade-offs
+
+- **Risco:** Nenhum. Comentários não afetam compilação, testes ou runtime.
+- **Trade-off:** A numeração ficará 1, 2, 3 dentro de `executeReviewJob`, enquanto outras funções do mesmo arquivo também usam `1` como ponto inicial — isso é aceitável pois o contexto (nome da função) delimita o escopo de cada sequência.

--- a/docs/specs/12-severidade-low-quality/REQUIREMENTS.md
+++ b/docs/specs/12-severidade-low-quality/REQUIREMENTS.md
@@ -1,0 +1,37 @@
+# Requisitos — Issue #12: Comentário duplicado em `executeReviewJob`
+
+## Resumo do Problema
+
+No arquivo `automation/server.js`, dentro da função `executeReviewJob`, existe um comentário duplicado: `// Ponto de verificação 2` aparece duas vezes seguidas — uma na linha ~916 (para inspeção do `diff`) e outra na linha ~927 (para inspeção do `existingComments`). Isso prejudica a legibilidade e a rastreabilidade do código, pois ambos os blocos fazem coisas diferentes mas possuem o mesmo rótulo.
+
+**Localização exata:**
+- `automation/server.js:916` — `// Ponto de verificação 2 — verificar diff antes de passar ao Claude`
+- `automation/server.js:927` — `// Ponto de verificação 2 — verificar existingComments antes de passar ao Claude`
+
+## Requisitos Funcionais
+
+1. O comentário na linha 916 deve identificar de forma única o ponto de verificação de injeção sobre o `diff`. Pode permanecer como `// Ponto de verificação 2` (já tem sufixo descritivo) ou ser renomeado para algo como `// Verificação de injeção no diff`.
+2. O comentário na linha 927 deve ser renomeado para identificar de forma única o ponto de verificação de injeção sobre os `existingComments`. Deve ser numerado sequencialmente como `// Ponto de verificação 3` ou receber um nome descritivo como `// Verificação de injeção nos comentários existentes`.
+3. Nenhum outro comportamento de runtime deve ser alterado — apenas os textos dos comentários.
+
+## Requisitos Não-Funcionais
+
+- **Legibilidade:** Após a correção, cada ponto de verificação dentro de `executeReviewJob` deve ter um identificador único e autoexplicativo.
+- **Consistência:** O estilo do comentário corrigido deve seguir o padrão já utilizado nos demais pontos de verificação do arquivo (ex: `// Ponto de verificação 1 — review job: verificar title` na linha ~1086).
+
+## Escopo
+
+### Incluído
+- Correção dos dois comentários duplicados em `automation/server.js` dentro de `executeReviewJob` (linhas ~916 e ~927).
+
+### Excluído
+- Qualquer alteração de lógica, comportamento ou estrutura do código.
+- Outros arquivos que não sejam `automation/server.js`.
+- Refatoração de outros comentários no arquivo.
+
+## Critérios de Aceitação
+
+1. O arquivo `automation/server.js` não deve conter dois comentários com o texto `// Ponto de verificação 2` idêntico (ou com o mesmo número de sequência repetido na mesma função).
+2. O comentário referente à verificação de `diff` e o comentário referente à verificação de `existingComments` devem ser distintos e identificáveis.
+3. Nenhum teste existente deve falhar após a alteração.
+4. O comportamento em runtime de `executeReviewJob` deve ser idêntico ao anterior (a mudança é puramente cosmética).

--- a/docs/specs/12-severidade-low-quality/TASKS.md
+++ b/docs/specs/12-severidade-low-quality/TASKS.md
@@ -1,0 +1,10 @@
+# Tarefas — Issue #12: Comentário duplicado em `executeReviewJob`
+
+## 1. Correção do Comentário
+
+- [x] 1.1 Em `automation/server.js` na linha ~927, alterar o texto do comentário de `// Ponto de verificação 2 — verificar existingComments antes de passar ao Claude` para `// Ponto de verificação 3 — verificar existingComments antes de passar ao Claude`
+
+## 2. Verificação
+
+- [x] 2.1 Confirmar que não há mais dois comentários com o mesmo identificador `// Ponto de verificação 2` dentro da função `executeReviewJob` em `automation/server.js`
+- [x] 2.2 Confirmar que nenhum teste existente falha após a alteração


### PR DESCRIPTION
## Resumo das mudanças

Corrige comentário duplicado `Ponto de verificação 2` na função `executeReviewJob`.

### Problema
A função `executeReviewJob` continha dois comentários idênticos `Ponto de verificação 2`, causando confusão na leitura e manutenção do código (issue de qualidade de baixa severidade).

### Solução
Renomeou o segundo comentário para `Ponto de verificação 3`, tornando a sequência de checkpoints clara e não ambígua.

### Arquivos alterados
- Comentário duplicado removido/renomeado em `executeReviewJob`

Closes #12